### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "project management"
   ],
   "description": "Filters images and provides results in selected format",
-  "docker_image": "supervisely/data-operations:6.73.564",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
   "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/config.json
+++ b/config.json
@@ -10,7 +10,7 @@
     "project management"
   ],
   "description": "Filters images and provides results in selected format",
-  "docker_image": "supervisely/data-operations:6.73.486",
+  "docker_image": "supervisely/data-operations:6.73.564",
   "instance_version": "6.15.35",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,

--- a/config.json
+++ b/config.json
@@ -11,7 +11,7 @@
   ],
   "description": "Filters images and provides results in selected format",
   "docker_image": "supervisely/data-operations:6.73.564",
-  "instance_version": "6.15.35",
+  "instance_version": "6.15.60",
   "entrypoint": "python -m uvicorn src.main:g.app --host 0.0.0.0 --port 8000",
   "port": 8000,
   "task_location": "workspace_tasks",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.486
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
